### PR TITLE
Improved payout function to remove potential attacks

### DIFF
--- a/contracts/attackerContract.sol
+++ b/contracts/attackerContract.sol
@@ -1,0 +1,54 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.4;
+import "./NFTAuction.sol";
+
+contract attackerContract {
+    uint256 public balanceOfContract;
+    NFTAuction auction;
+    uint256 tokenID;
+    address erc721;
+    uint256 amount;
+    bool reverts;
+    bool withdrawFail;
+
+    function setAuctionContract(address _auctionContract) external {
+        auction = NFTAuction(_auctionContract);
+    }
+
+    function bidOnAuction(
+        address _erc721,
+        uint256 _token,
+        uint256 _amount
+    ) external {
+        auction.makeBid{value: _amount}(_erc721, _token, address(0), 0);
+        erc721 = _erc721;
+        tokenID = _token;
+        amount = _amount;
+        balanceOfContract -= _amount;
+    }
+
+    function setRequire(bool _req) external {
+        reverts = _req;
+    }
+
+    function withdraw() public {
+        auction.withdrawBid(erc721, tokenID);
+    }
+
+    function deposit() external payable {
+        balanceOfContract += msg.value;
+    }
+
+    function withdrawFailed() external payable {
+        withdrawFail = true;
+        auction.withdrawAllFailedCredits();
+    }
+
+    receive() external payable {
+        balanceOfContract += msg.value;
+        require(reverts, "Cause failure to block next bidder");
+        if (!withdrawFail) {
+            withdraw(); //attempt to withdraw again
+        }
+    }
+}

--- a/test/new-auction-tests.js
+++ b/test/new-auction-tests.js
@@ -296,5 +296,10 @@ describe("NFTAuction", function () {
         user1.address
       );
     });
+    it("should not allow user to withdraw 0 failedCredit Balance", async function () {
+      await expect(
+        nftAuction.connect(user3).withdrawAllFailedCredits()
+      ).to.be.revertedWith("no credits to withdraw");
+    });
   });
 });


### PR DESCRIPTION
Changed .transfer function for transfer ETH to use .call{value:}, so that we can avoid a malicious user blocking all future bids if they revert in their receive/fallback function.