### PR TITLE
Fix: erc20 enabled sales issue with creation of second eth sale

### DIFF
--- a/contracts/NFTAuction.sol
+++ b/contracts/NFTAuction.sol
@@ -153,7 +153,7 @@ contract NFTAuction {
                 msg.sender == IERC721(_nftContractAddress).ownerOf(_tokenId),
                 "Sender doesn't own NFT"
             );
-
+            _reverseAndResetPreviousBid(_nftContractAddress, _tokenId);
             _resetAuction(_nftContractAddress, _tokenId);
         }
         _;
@@ -1096,8 +1096,9 @@ contract NFTAuction {
             _tokenId
         ].nftHighestBid;
         _resetBids(_nftContractAddress, _tokenId);
-
+        if (nftHighestBidder != address(0)) {
         _payout(_nftContractAddress, _tokenId, nftHighestBidder, nftHighestBid);
+        }
     }
 
     function _reversePreviousBidAndUpdateHighestBid(
@@ -1261,6 +1262,7 @@ contract NFTAuction {
             IERC721(_nftContractAddress).ownerOf(_tokenId) == msg.sender,
             "Not NFT owner"
         );
+         _reverseAndResetPreviousBid(_nftContractAddress, _tokenId);
         _resetAuction(_nftContractAddress, _tokenId);
         emit AuctionWithdrawn(_nftContractAddress, _tokenId, msg.sender);
     }


### PR DESCRIPTION
This fix should allow for any erc20 sale to work correctly when recreated with an ETH buyNow price